### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "frozzare/wp-cli-lint",
   "description": "WP-CLI command for linting your code",
-  "type": "command",
+  "type": "wp-cli-package",
   "keywords": ["wp-cli", "wordpress"],
   "homepage": "https://github.com/frozzare/wp-cli-lint",
   "license": "MIT",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
